### PR TITLE
Allow disabling Requires with ENV["JULIA_REQUIRES_DISABLED"]=1

### DIFF
--- a/src/require.jl
+++ b/src/require.jl
@@ -77,7 +77,7 @@ macro require(pkg, expr)
   id, modname = parsepkg(pkg)
   pkg = :(Base.PkgId(Base.UUID($id), $modname))
   quote
-    if !isprecompiling()
+    if !isprecompiling() && get(ENV, "JULIA_REQUIRES_DISABLED", "0") != "1"
       listenpkg($pkg) do
         $withnotifications($(string(__source__.file)), $__module__, $id, $modname, $(esc(Expr(:quote, expr))))
         withpath($(string(__source__.file))) do


### PR DESCRIPTION
It would be good to be able to switch-off the invocation within `Requires.@require` at a high level. This proposes a method via setting `ENV["JULIA_REQUIRES_DISABLED"]=1`

### Reasoning
As is known, Requires skips precompilation https://github.com/JuliaLang/Pkg.jl/issues/1285, and causes problems for redistributable PackageCompiler-ed sysimages https://discourse.julialang.org/t/zygote-jl-and-packagecompiler-jl/35839/2

Packages that contain `@init @requires` usage _can_ be functional through PackageCompiler (even though the `@require`-ed code isn't precompiled) given that the absolute paths of the system are identical.

That breaks for redistribution of the sysimage/application given the use of the `__source__.file` absolute paths within the `@requires` macro.


This PR is a band-aid to allow manual disabling of `@require` invocations, if the user decides that's ok.

I have a situation where that is ok: 
The package (FooPackage) I'm sysimaging uses Zygote via Flux, and doesn't need the Zygote's `@require`-ed conditional functionality for Distances and StatsFun https://github.com/FluxML/Zygote.jl/blob/1da9463f751768d423a3bc5ef9a0831b17b8c5af/src/Zygote.jl#L34-L35
My package also uses ImageDraw, which loads Distances, and other packages that load StatsFun. 

If I sysimage FooPackage and run the sysimage on another machine, as soon as ImageDraw loads, `@requires` crashes during init due to absolute paths from the sysimage being wrong.

With this PR, I could set `ENV["JULIA_REQUIRES_DISABLED"]=1` before loading FooPackage to skip all the `@require`-ed stuff, which I know is ok.

Without this PR, deploying fast-loading code that uses `Requires` may not be possible (I'm open to other fixes, if there are any).
