### PR TITLE
Include macro for building sysimgs

### DIFF
--- a/src/Requires.jl
+++ b/src/Requires.jl
@@ -2,6 +2,21 @@ module Requires
 
 using UUIDs
 
+"""
+    @include("file.jl")
+
+Behaves like `include`, but loads the target file contents at load-time before
+evaluating its contents at runtime. This is useful when the target file may not
+be available at runtime (for example, because of compiling a sysimg).
+
+`@require` blocks insert this automatically when you use `include`.
+"""
+macro include(file)
+    file = joinpath(dirname(String(__source__.file)), file)
+    s = String(read(file))
+    :(include_string($__module__, $s, $file))
+end
+
 include("init.jl")
 include("require.jl")
 

--- a/src/require.jl
+++ b/src/require.jl
@@ -87,6 +87,7 @@ macro require(pkg, expr)
   id, modname = parsepkg(pkg)
   pkg = :(Base.PkgId(Base.UUID($id), $modname))
   expr = replace_include(expr, __source__)
+  expr = macroexpand(__module__, expr)
   quote
     if !isprecompiling()
       listenpkg($pkg) do

--- a/src/require.jl
+++ b/src/require.jl
@@ -72,7 +72,7 @@ end
 
 function replace_include(ex, source)
   if isexpr(ex, :call) && ex.args[1] == :include && ex.args[2] isa String
-    return Expr(:macrocall, :($Requires.var"@include"), source, ex.args[2])
+    return Expr(:macrocall, :($Requires.$(Symbol("@include"))), source, ex.args[2])
   elseif ex isa Expr
     Expr(ex.head, replace_include.(ex.args, (source,))...)
   else


### PR DESCRIPTION
This PR adds an `@include` macro which behaves like `include`, but is more compatible with compiling a sysimg.

Separately, it also adds a hook to replace `include` statements in `@require` block with `@include`. This risks being a bit magical but shouldn't affect normal usage at all, only sysimg usage. The main edge case is recursive `include` during sysimg compilation (e.g. file included by Requires has another `include` in it). Since this is pretty uncommon, it should make most Requires usage just work with sysimg building.