### PR TITLE
Add more precompile and fix an inference problem

### DIFF
--- a/src/Requires.jl
+++ b/src/Requires.jl
@@ -15,6 +15,7 @@ if isprecompiling()
     @assert precompile(err, (Any, Module, String))
     @assert precompile(parsepkg, (Expr,))
     @assert precompile(listenpkg, (Any, Base.PkgId))
+    @assert precompile(callbacks, (Base.PkgId,))
 end
 
 end # module

--- a/src/require.jl
+++ b/src/require.jl
@@ -10,7 +10,7 @@ loaded(pkg) = haskey(Base.loaded_modules, pkg)
 const notified_pkgs = [Base.PkgId(UUID(0x295af30fe4ad537b898300126c2a3abe), "Revise")]
 
 const _callbacks = Dict{PkgId, Vector{Function}}()
-callbacks(pkg) = get!(()->[], _callbacks, pkg)
+callbacks(pkg) = get!(()->Function[], _callbacks, pkg)
 
 listenpkg(@nospecialize(f), pkg) =
   loaded(pkg) ? f() : push!(callbacks(pkg), f)

--- a/src/require.jl
+++ b/src/require.jl
@@ -10,7 +10,7 @@ loaded(pkg) = haskey(Base.loaded_modules, pkg)
 const notified_pkgs = [Base.PkgId(UUID(0x295af30fe4ad537b898300126c2a3abe), "Revise")]
 
 const _callbacks = Dict{PkgId, Vector{Function}}()
-callbacks(pkg) = get!(()->Function[], _callbacks, pkg)
+callbacks(pkg) = get!(Vector{Function}, _callbacks, pkg)
 
 listenpkg(@nospecialize(f), pkg) =
   loaded(pkg) ? f() : push!(callbacks(pkg), f)


### PR DESCRIPTION
This shaves about 30ms off the time to load a simple Requires-dependent package; not a ton, but pretty consistent and worth having given how many packages use Requires.

This does not eliminate all runtime inference when using Requires; `get!` simply refuses to completely precompile (probably https://github.com/JuliaLang/julia/pull/32705?), although this helps.