### PR TITLE
Use standard `exception` field for require warning

### DIFF
--- a/src/require.jl
+++ b/src/require.jl
@@ -40,11 +40,8 @@ end
 function err(@nospecialize(f), listener, mod)
   try
     f()
-  catch e
-    @warn """
-      Error requiring $mod from $listener:
-      $(sprint(showerror, e, catch_backtrace()))
-      """
+  catch exc
+    @warn "Error requiring `$mod` from `$listener`" exception=(exc,catch_backtrace())
   end
 end
 


### PR DESCRIPTION
This produces better pretty printing of the error message for logging
backends which support the standard exception field.

Eg with `TerminalLoggers.TerminalLogger`, new printing:

```
┌ Warning: Error requiring DataSets from MyTest
│   exception =
│    oh noes
│    Stacktrace:
│     [1] error(::String) at ./error.jl:33
│     [2] top-level scope at /home/chris/tmp/MyTest/src/MyTest.jl:13
│     [3] eval at ./boot.jl:331 [inlined]
│     [4] eval at /home/chris/tmp/MyTest/src/MyTest.jl:1 [inlined]
│     [5] (::MyTest.var"#3#6")() at /home/chris/.julia/dev/Requires/src/require.jl:94
│     [6] err(::Any, ::Module, ::String) at /home/chris/.julia/dev/Requires/src/require.jl:42
│     [7] (::MyTest.var"#2#5")() at /home/chris/.julia/dev/Requires/src/require.jl:93
...
```

vs old printing:

```
┌ Warning: Error requiring DataSets from MyTest: oh noes Stacktrace: [1] error(::String) at ./error.jl:33 [2] top-level scope at /home/chris/tmp/MyTest/src/MyTest.jl:13 [3] eval at
│ ./boot.jl:331 [inlined] [4] eval at /home/chris/tmp/MyTest/src/MyTest.jl:1 [inlined] 5 (::MyTest.var"#3#6")() at /home/chris/.julia/dev/Requires/src/require.jl:97 [6] err(::Any,
│ ::Module, ::String) at /home/chris/.julia/dev/Requires/src/require.jl:42 7 (::MyTest.var"#2#5")() at /home/chris/.julia/dev/Requires/src/require.jl:96 [8] withpath(::Any, ::String)
│ at /home/chris/.julia/dev/Requires/src/require.jl:32 9 (::MyTest.var"#1#4")() at /home/chris/.julia/dev/Requires/src/require.jl:95 [10] #invokelatest#1 at ./essentials.jl:710
│ [inlined] [11] invokelatest at ./essentials.jl:709 [inlined] [12] foreach at ./abstractarray.jl:2009 [inlined] [13] loadpkg(::Base.PkgId) at
│ /home/chris/.julia/dev/Requires/src/require.jl:22 [14] #invokelatest#1 at ./essentials.jl:710 [inlined] [15] invokelatest at ./essentials.jl:709 [inlined] [16]
│ require(::Base.PkgId) at ./loading.jl:931 [17] require(::Module, ::Symbol) at ./loading.jl:923 [18] eval(::Module, ::Any) at ./boot.jl:331 [19] evaluserinput(::Any,
...
```