### PR TITLE
Reduce latency

### DIFF
--- a/src/Requires.jl
+++ b/src/Requires.jl
@@ -48,14 +48,14 @@ function __init__()
 end
 
 if isprecompiling()
-    @assert precompile(loadpkg, (Base.PkgId,))
-    @assert precompile(withpath, (Any, String))
-    @assert precompile(err, (Any, Module, String))
-    @assert precompile(parsepkg, (Expr,))
-    @assert precompile(listenpkg, (Any, Base.PkgId))
-    @assert precompile(callbacks, (Base.PkgId,))
-    @assert precompile(withnotifications, (Vararg{Any},))
-    @assert precompile(withnotifications, (Any, Vararg{Any},))
+    precompile(loadpkg, (Base.PkgId,)) || @warn "Requires failed to precompile `loadpkg`"
+    precompile(withpath, (Any, String)) || @warn "Requires failed to precompile `withpath`"
+    precompile(err, (Any, Module, String)) || @warn "Requires failed to precompile `err`"
+    precompile(parsepkg, (Expr,)) || @warn "Requires failed to precompile `parsepkg`"
+    precompile(listenpkg, (Any, Base.PkgId)) || @warn "Requires failed to precompile `listenpkg`"
+    precompile(callbacks, (Base.PkgId,)) || @warn "Requires failed to precompile `callbacks`"
+    precompile(withnotifications, (Vararg{Any,100},)) || @warn "Requires failed to precompile `withnotifications`"
+    precompile(replace_include, (Any, LineNumberNode)) || @warn "Requires failed to precompile `replace_include`"
 end
 
 end # module

--- a/src/Requires.jl
+++ b/src/Requires.jl
@@ -56,6 +56,7 @@ if isprecompiling()
     precompile(callbacks, (Base.PkgId,)) || @warn "Requires failed to precompile `callbacks`"
     precompile(withnotifications, (Vararg{Any,100},)) || @warn "Requires failed to precompile `withnotifications`"
     precompile(replace_include, (Any, LineNumberNode)) || @warn "Requires failed to precompile `replace_include`"
+    precompile(getfield(Requires, Symbol("@require")), (LineNumberNode, Module, Expr, Any)) || @warn "Requires failed to precompile `@require`"
 end
 
 end # module

--- a/src/Requires.jl
+++ b/src/Requires.jl
@@ -1,7 +1,7 @@
 module Requires
 
 if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@compiler_options"))
-    Base.Experimental.@compiler_options compile=min optimize=0 infer=false
+    @eval Base.Experimental.@compiler_options compile=min optimize=0 infer=false
 end
 
 using UUIDs


### PR DESCRIPTION
The following benchmark:
```julia
julia> using Example

julia> id = Base.module_keys[Example]
Example [7876af07-990d-54b4-ab0e-23690620f79a]

julia> @time begin
       @eval module SomeMod
             using Requires
             __init__() = @require Example="7876af07-990d-54b4-ab0e-23690620f79a" f(x) = x^2
             end
       end
  0.335103 seconds (512.40 k allocations: 30.980 MiB, 8.35% gc time)
Main.SomeMod
```

has substantial latency. This PR cuts it to less than half:
  0.145450 seconds (178.21 k allocations: 10.709 MiB)

It also makes the precompiles less fragile.