### PR TITLE
Issue notifications after loading package

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,50 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+    tags: '*'
+  pull_request:
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.0'
+          - '1.6'
+          - '1'
+          - 'nightly'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v2
+        with:
+          files: lcov.info

--- a/src/require.jl
+++ b/src/require.jl
@@ -93,7 +93,6 @@ macro require(pkg::Union{Symbol,Expr}, expr)
   quote
     if !isprecompiling()
       listenpkg($pkg) do
-        $withnotifications($srcfile, $__module__, $idstr, $modname, $(esc(Expr(:quote, expr))))
         withpath($srcfile) do
           err($__module__, $modname) do
             $(esc(:(eval($(Expr(:quote, Expr(:block,
@@ -101,6 +100,7 @@ macro require(pkg::Union{Symbol,Expr}, expr)
                                             expr)))))))
           end
         end
+        $withnotifications($srcfile, $__module__, $idstr, $modname, $(esc(Expr(:quote, expr))))
       end
     end
   end


### PR DESCRIPTION
Other packages can set up callbacks to be notified about `@require`
blocks. Previously, the notification was issued before Requires
set the `const` for the module name in the package that set up
the `@require` block. This PR changes it so that those notifications
are sent afterwards, thus ensuring that the `const` will be defined
by the time "consumers" get notified.

This is a potentially-breaking change. Since it would cause huge
`[compat]` churn to bump the major version, given the considerations
below I think we can safely use a minor-version bump:

- Requires' README does not promise any particular ordering.

- This ordering seems to make a bit more sense.

- Revise appears to be the only user of this functionality based on
  the lack of any other entries in `notified_pkgs` and a search of
  JuliaHub

- This change fixes https://github.com/timholy/Revise.jl/issues/658.
  The bug was triggered by Revise changes that processed inputs eagerly,
  in response to new locks to make `Base.require` threadsafe in the
  upcoming Julia 1.8 release.