### PR TITLE
Add debug log for monitoring `@require` time

### DIFF
--- a/src/Requires.jl
+++ b/src/Requires.jl
@@ -54,7 +54,8 @@ end
 if isprecompiling()
     precompile(loadpkg, (Base.PkgId,)) || @warn "Requires failed to precompile `loadpkg`"
     precompile(withpath, (Any, String)) || @warn "Requires failed to precompile `withpath`"
-    precompile(err, (Any, Module, String)) || @warn "Requires failed to precompile `err`"
+    precompile(err, (Any, Module, String, String, Int)) || @warn "Requires failed to precompile `err`"
+    precompile(err, (Any, Module, String, String, Nothing)) || @warn "Requires failed to precompile `err`"
     precompile(parsepkg, (Expr,)) || @warn "Requires failed to precompile `parsepkg`"
     precompile(listenpkg, (Any, Base.PkgId)) || @warn "Requires failed to precompile `listenpkg`"
     precompile(callbacks, (Base.PkgId,)) || @warn "Requires failed to precompile `callbacks`"


### PR DESCRIPTION
Adds a debug log so you can monitor `@require`s that get triggered and the time spent running code

```julia
julia> ENV["JULIA_DEBUG"]="Requires"
"Requires"

julia> using Foo
┌ Debug: Requires conditionally ran code in 0.917808094 seconds: `Ratios` detected `FixedPointNumbers`
└ @ Requires ~/.julia/packages/Ratios/xLeZh/src/Ratios.jl:123
┌ Debug: Requires conditionally ran code in 0.531145239 seconds: `ArrayInterface` detected `SuiteSparse`
└ @ Requires ~/.julia/packages/ArrayInterface/mI7ab/src/ArrayInterface.jl:675
┌ Debug: Requires conditionally ran code in 0.002734456 seconds: `ArrayInterface` detected `Adapt`
└ @ Requires ~/.julia/packages/ArrayInterface/mI7ab/src/ArrayInterface.jl:760
┌ Debug: Requires conditionally ran code in 0.029623663 seconds: `ArrayInterface` detected `StaticArrays`
└ @ Requires ~/.julia/packages/ArrayInterface/mI7ab/src/ArrayInterface.jl:690
┌ Debug: Requires conditionally ran code in 0.006599821 seconds: `ArrayInterface` detected `OffsetArrays`
└ @ Requires ~/.julia/packages/ArrayInterface/mI7ab/src/ArrayInterface.jl:1116
┌ Debug: Requires conditionally ran code in 0.022674606 seconds: `HDF5` detected `FileIO`
└ @ Requires ~/.julia/packages/HDF5/pIJra/src/HDF5.jl:2133
┌ Debug: Requires conditionally ran code in 0.002288416 seconds: `RandomNumbers` detected `Random123`
└ @ Requires ~/.julia/packages/RandomNumbers/3pD1N/src/RandomNumbers.jl:38
┌ Debug: Requires conditionally ran code in 1.708197842 seconds: `CUDA` detected `SpecialFunctions`
└ @ Requires ~/.julia/packages/CUDA/sCev8/src/initialization.jl:35
┌ Debug: Requires conditionally ran code in 0.0126559 seconds: `ArrayInterface` detected `Adapt`
└ @ Requires ~/.julia/packages/ArrayInterface/mI7ab/src/ArrayInterface.jl:796
┌ Debug: Requires conditionally ran code in 0.029985851 seconds: `ArrayInterface` detected `CUDA`
└ @ Requires ~/.julia/packages/ArrayInterface/mI7ab/src/ArrayInterface.jl:795
┌ Debug: Requires conditionally ran code in 2.06503522 seconds: `Zygote` detected `CUDA`
└ @ Requires ~/.julia/packages/Zygote/umM0L/src/lib/broadcast.jl:251
┌ Debug: Requires conditionally ran code in 0.211960078 seconds: `Zygote` detected `Distances`
└ @ Requires ~/.julia/packages/Zygote/umM0L/src/Zygote.jl:45
┌ Debug: Requires conditionally ran code in 0.258361828 seconds: `Zygote` detected `LogExpFunctions`
└ @ Requires ~/.julia/packages/Zygote/umM0L/src/Zygote.jl:46
┌ Debug: Requires conditionally ran code in 0.003038184 seconds: `Zygote` detected `Colors`
└ @ Requires ~/.julia/packages/Zygote/umM0L/src/Zygote.jl:60
┌ Debug: Requires conditionally ran code in 0.284711345 seconds: `ImageMorphology` detected `ImageMetadata`
└ @ Requires ~/.julia/packages/ImageMorphology/6oqcS/src/ImageMorphology.jl:65
┌ Debug: Requires conditionally ran code in 0.002487405 seconds: `RegisterCore` detected `ImageMetadata`
└ @ Requires ~/.julia/packages/RegisterCore/YuSsR/src/RegisterCore.jl:397

julia> 
```

cc. @ChrisRackauckas I think you were also after something like this