### PR TITLE
Steer readers to Package Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 For older versions of Julia, see https://github.com/MikeInnes/Requires.jl/blob/5683745f03cbea41f6f053182461173e236fdd94/README.md
 
+For Julia 1.9 and higher, Package Extensions is preferable;
+see
+[the Julia manual](https://docs.julialang.org/en/v1/manual/code-loading/#man-extensions).
+
 # Requires.jl
 
 [![Build Status](https://travis-ci.org/MikeInnes/Requires.jl.svg?branch=master)](https://travis-ci.org/MikeInnes/Requires.jl)


### PR DESCRIPTION
Should address #113

This PR assumes that Package Extensions is indeed the recommended route now.
If that is not the case, then the README should provide users with guidance
about when to use which approach.

For reference, there is a discourse discussion of how to serve both Julia 1.9 and above as well as earlier versions:
https://discourse.julialang.org/t/package-extensions-for-julia-1-9/93397

(I share Tim Holy's view there that it is not worth the effort, but if someone wants to put in the effort to update the README here to document it then please do!)